### PR TITLE
Laravel 11 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,14 +12,20 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.4, '8.0', 8.1, 8.2]
-        laravel: [8, 9, 10]
+        laravel: [8, 9, 10, 11]
         exclude:
           - php: 7.4
             laravel: 9
           - php: 7.4
             laravel: 10
+          - php: 7.4
+            laravel: 11
           - php: '8.0'
             laravel: 10
+          - php: '8.0'
+            laravel: 11
+          - php: 8.1
+            laravel: 11
           - php: 8.2
             laravel: 8
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,4 +49,4 @@ jobs:
           composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4, '8.0', 8.1, 8.2]
+        php: [7.4, '8.0', 8.1, 8.2, 8.3]
         laravel: [8, 9, 10, 11]
         exclude:
           - php: 7.4
@@ -28,6 +28,10 @@ jobs:
             laravel: 11
           - php: 8.2
             laravel: 8
+          - php: 8.3
+            laravel: 8
+          - php: 8.3
+            laravel: 9
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     "require": {
         "php": "^7.4|^8.0",
         "blade-ui-kit/blade-icons": "^1.1",
-        "illuminate/support": "^8.0|^9.0|^10.0"
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "codeat3/blade-icon-generation-helpers": "^0.3",
         "codeat3/phpcs-styles": "^1.0",
-        "orchestra/testbench": "^6.0|^7.0|^8.0",
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
         "phpunit/phpunit": "^9.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/support": "^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
-        "codeat3/blade-icon-generation-helpers": "^0.3",
+        "codeat3/blade-icon-generation-helpers": "dev-cat-lps2.3",
         "codeat3/phpcs-styles": "^1.0",
         "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
         "phpunit/phpunit": "^9.0"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/support": "^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
-        "codeat3/blade-icon-generation-helpers": "dev-cat-lps2.3",
+        "codeat3/blade-icon-generation-helpers": "0.8",
         "codeat3/phpcs-styles": "^1.0",
         "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
         "phpunit/phpunit": "^9.0|^10.5|^11.0"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "codeat3/blade-icon-generation-helpers": "dev-cat-lps2.3",
         "codeat3/phpcs-styles": "^1.0",
         "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^9.0|^10.5|^11.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hi there,

Laravel 11 is coming soon, at the beginning of March 2024. To prepare for the release and make sure the FluentUI system icons can be used for all users upgrading from L10 to L11, we should upgrade this repo early so it's ready before release day.